### PR TITLE
Adicionando idade para gatos

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -25,12 +25,6 @@ jobs:
 
     - name: Test
       run: go test -v -coverprofile=coverage.out
-    
-    - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Build
       run: go build -v .


### PR DESCRIPTION
Agora é possível calcular também a idade de gatos.

Na página inicial terá um menu que tem como opções

- Idade de cachorro (que é o valor padrão)
- Idade de gato

Para testar:

- Você deve clicar no menu e escolher a opção "idade de gato"
- Colocar qualquer valor numérico
- O resultado deve ser também numérico
- Tente colocar um valor não numérico, o erro deve ser uma mensagem de tratamento informando que apenas valores numéricos são permitidos